### PR TITLE
🧪 Add check for empty argument in validate-docker-compose.sh

### DIFF
--- a/scripts/validate-docker-compose.sh
+++ b/scripts/validate-docker-compose.sh
@@ -4,6 +4,12 @@
 # Exit immediately if a command exits with a non-zero status.
 set -e
 
+# Check if an argument was provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <docker-compose-file>" >&2
+    exit 1
+fi
+
 COMPOSE_FILE="$1"
 
 # Check if the file exists

--- a/tests/test-validate-docker-compose.sh
+++ b/tests/test-validate-docker-compose.sh
@@ -31,7 +31,11 @@ run_test() {
     local test_name=$3
 
     set +e
-    bash "$VALIDATE_SCRIPT" "$compose_file" > /dev/null 2>&1
+    if [ -z "$compose_file" ]; then
+        bash "$VALIDATE_SCRIPT" > /dev/null 2>&1
+    else
+        bash "$VALIDATE_SCRIPT" "$compose_file" > /dev/null 2>&1
+    fi
     local actual_exit_code=$?
     set -e
 
@@ -61,5 +65,8 @@ run_test "$TEMP_DIR/docker-compose.yml" 1 "docker-compose missing"
 # Case 4: Failure - Provided file does not exist
 create_mock_docker_compose 0
 run_test "$TEMP_DIR/non-existent.yml" 1 "File does not exist"
+
+# Case 5: Failure - No arguments provided
+run_test "" 1 "No arguments provided"
 
 echo "All tests passed!"


### PR DESCRIPTION
🧪 Add check for empty argument in validate-docker-compose.sh

This PR adds an explicit check for the number of arguments in the `scripts/validate-docker-compose.sh` script.

### Changes:
- **`scripts/validate-docker-compose.sh`**: Added a check to ensure at least one argument is provided. If not, it prints a usage message and exits with an error status.
- **`tests/test-validate-docker-compose.sh`**: Updated the `run_test` helper to support empty arguments and added a new test case "No arguments provided".

### Verification:
- Ran `bash tests/test-validate-docker-compose.sh` and all tests (including the new one) passed.
- Manually verified the error message and exit code by running `bash scripts/validate-docker-compose.sh`.


---
*PR created automatically by Jules for task [16742587837759951087](https://jules.google.com/task/16742587837759951087) started by @lvlie*