### PR TITLE
Add open-webui service with Cloudflare authentication

### DIFF
--- a/man/docker-compose.yml
+++ b/man/docker-compose.yml
@@ -65,3 +65,13 @@ services:
       - 5432:5432
     restart: unless-stopped
     shm_size: 256mb
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    hostname: open-webui
+    environment:
+      - TZ=Europe/Amsterdam
+      - WEBUI_AUTH_TRUSTED_EMAIL_HEADER=Cf-Access-Authenticated-User-Email
+    volumes:
+      - /data/open-webui:/app/backend/data
+    restart: unless-stopped


### PR DESCRIPTION
This PR adds the `open-webui` service to the `man/docker-compose.yml` file. It maps the container's data directory to a local folder (`/data/open-webui`) and configures the environment variable (`WEBUI_AUTH_TRUSTED_EMAIL_HEADER`) to trust the `Cf-Access-Authenticated-User-Email` header, enabling the requested Cloudflare Zero Trust authentication flow.

---
*PR created automatically by Jules for task [2480165718020624910](https://jules.google.com/task/2480165718020624910) started by @lvlie*